### PR TITLE
impl separate post. remove warnings(upgrade @octokit/rest:16.28.0)

### DIFF
--- a/.replrc.js
+++ b/.replrc.js
@@ -1,11 +1,10 @@
 require('dotenv').config();
 
 const github_token = process.env.GITHUB_TOKEN;
-const octokit = require('@octokit/rest')();
+const Octokit = require('@octokit/rest');
 
-octokit.authenticate({
-  type: 'token',
-  token: github_token
+const octokit = new Octokit({
+  auth: 'token ' + github_token
 });
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,13 @@
     "repl": "local-repl"
   },
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dany1468/pr_notifier.git"
+  },
   "license": "ISC",
   "dependencies": {
-    "@octokit/rest": "^15.9.1",
+    "@octokit/rest": "^16.28.0",
     "@slack/client": "^4.3.1",
     "dotenv": "^6.0.0"
   },


### PR DESCRIPTION
slack への post を PR 毎に分ける機能を実装しました。
モチベーションとしては post 毎に reaction ができるようにするためです。

"-separate" オプションで有効になります。

- 環境変数を汚すまでもないと思ってパラメーターにしています。(良い環境変数名が思いつかなかったのも一因)
- コマンドラインパーサーを入れるほどでもないと思ったので雑に実装してます。 😅 

post 毎に sleep 入れているのは slack の Rate Limits によるものです。
> Incoming webhooks	1 per second	short bursts >1 allowed
> https://api.slack.com/docs/rate-limits

あと before-after-hook で deprecated warning がでていたので @octokit/rest を 16.28.0 にバージョンアップしました。
https://git.io/upgrade-before-after-hook-to-1.4